### PR TITLE
AdmittanceModels.jl submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "AdmittanceModels.jl"]
+	path = AdmittanceModels.jl
+	url = https://github.com/rigetti/AdmittanceModels.jl.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,3 @@ julia:
   - 1.1
 notifications:
   email: false
-
-jobs:
-  include:
-    - stage: "Documentation"
-      julia: 1.1
-      os: linux
-      script:
-        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
-                                               Pkg.instantiate()'
-        - julia --project=docs/ docs/make.jl
-      after_success: skip
-after_success: skip

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -4,7 +4,7 @@
 deps = ["Combinatorics", "IterativeSolvers", "LinearAlgebra", "MatrixNetworks", "SparseArrays", "Test", "UniqueVectors"]
 git-tree-sha1 = "21912c8e2c65d0a6e1e7bde2eb18254f875209e4"
 repo-rev = "master"
-repo-url = "git@github.com:rigetti/AdmittanceModels.jl.git"
+repo-url = "AdmittanceModels.jl"
 uuid = "88a7bace-b6cd-11e8-0e38-19740a683dcd"
 version = "0.1.0"
 
@@ -18,10 +18,10 @@ version = "0.3.1"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryProvider]]
-deps = ["Libdl", "SHA"]
+deps = ["Libdl", "Logging", "SHA"]
 git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.4"
+version = "0.5.6"
 
 [[Combinatorics]]
 deps = ["LinearAlgebra", "Polynomials", "Test"]
@@ -30,10 +30,10 @@ uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 version = "0.7.0"
 
 [[DataStructures]]
-deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
-git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
+deps = ["InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "0809951a1774dc724da22d26e4289bbaab77809a"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.15.0"
+version = "0.17.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -64,10 +64,9 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[IterTools]]
-deps = ["SparseArrays", "Test"]
-git-tree-sha1 = "79246285c43602384e6f1943b3554042a3712056"
+git-tree-sha1 = "2ebe60d7343962966d1779a74a760f13217a6901"
 uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-version = "1.1.1"
+version = "1.2.0"
 
 [[IterativeSolvers]]
 deps = ["LinearAlgebra", "Printf", "Random", "RecipesBase", "SparseArrays", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Michael Scheer <mgscheer@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+AdmittanceModels = "88a7bace-b6cd-11e8-0e38-19740a683dcd"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,8 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UniqueVectors = "2fbcfb34-fd0c-5fbb-b5d7-e826d8f5b0a9"
 
 [extras]
-AdmittanceModels = "88a7bace-b6cd-11e8-0e38-19740a683dcd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AdmittanceModels", "Test"]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # DiscreteExteriorCalculus.jl
 
+[travis-img]: https://travis-ci.com/rigetti/DiscreteExteriorCalculus.jl.svg?branch=master
+[travis-url]: https://travis-ci.com/rigetti/DiscreteExteriorCalculus.jl
+
+[![][travis-img]][travis-url]
+
 DiscreteExteriorCalculus.jl is a package implementing [Discrete Exterior Calculus](https://en.wikipedia.org/wiki/Discrete_exterior_calculus). Data structures for cell complexes, primal, and dual meshes are provided along with implementations of the [exterior derivative](https://en.wikipedia.org/wiki/Exterior_derivative),
 [hodge star](https://en.wikipedia.org/wiki/Hodge_star_operator), [codifferential](https://en.wikipedia.org/wiki/Hodge_star_operator#On_manifolds), and [Laplace-de Rham](https://en.wikipedia.org/wiki/Laplace%E2%80%93Beltrami_operator#Laplace%E2%80%93de_Rham_operator) operators.
 
 ## Installation
 
-Clone the repository from GitHub. No build is required beyond the default Julia compilation.
+Clone the repository from GitHub and install Julia 1.1. No build is required beyond the default Julia compilation.
 
 ## Example usage: modes of the Laplace-de Rham operator on a rectangle with Dirichlet boundary conditions
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,0 @@
-[deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-
-[compat]
-Documenter = "~0.22"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,0 @@
-using Documenter, DiscreteExteriorCalculus
-
-makedocs(modules = [DiscreteExteriorCalculus],
-    sitename="DiscreteExteriorCalculus.jl",
-    pages = ["Main" => "index.md"])
-
-deploydocs(
-    repo = "github.com/rigetti/DiscreteExteriorCalculus.jl.git",
-)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,0 @@
-# Docstrings
-
-```@autodocs
-Modules = [DiscreteExteriorCalculus]
-```


### PR DESCRIPTION
Adding AdmittanceModels.jl as a git submodule in order to make travis CI easier to set up.